### PR TITLE
fix: add language switcher to login screen

### DIFF
--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -15,8 +15,10 @@ import { GlassPanel } from "../components/GlassPanel";
 import { IconButton } from "../components/IconButton";
 import { PrimaryButton } from "../components/PrimaryButton";
 import { Screen } from "../components/Screen";
+import { SegmentedControl } from "../components/SegmentedControl";
 import { TextField } from "../components/TextField";
 import { useAuth } from "../features/auth/AuthProvider";
+import { usePreferences } from "../features/preferences/PreferencesProvider";
 import type { RootStackParamList } from "../navigation/types";
 import { spacing } from "../theme/colors";
 import { useAppTheme } from "../theme/ThemeProvider";
@@ -27,6 +29,7 @@ export function LoginScreen(_props: Props) {
   const { t } = useTranslation();
   const { colors } = useAppTheme();
   const { login, startLocalMode } = useAuth();
+  const { language, setLanguage } = usePreferences();
   const [serverUrl, setServerUrl] = useState("");
   const [username, setUsername] = useState("");
   const [appPassword, setAppPassword] = useState("");
@@ -159,6 +162,17 @@ export function LoginScreen(_props: Props) {
       <AppText muted variant="caption" style={styles.center}>
         {t("auth.secure")}{"\n"}{t("auth.localSubtitle")}
       </AppText>
+
+      <View style={styles.languagePicker}>
+        <SegmentedControl<"fr" | "en">
+          value={language}
+          onChange={(value) => void setLanguage(value)}
+          options={[
+            { label: t("settings.french"), value: "fr" },
+            { label: t("settings.english"), value: "en" }
+          ]}
+        />
+      </View>
     </Screen>
   );
 }
@@ -202,5 +216,8 @@ const styles = StyleSheet.create({
   tutorialStep: {
     flexDirection: "row",
     gap: spacing.sm
+  },
+  languagePicker: {
+    marginTop: spacing.md
   }
 });


### PR DESCRIPTION
Closes #16

## Problem

The language selector was only available in Settings, which requires an active session. Users who wanted to change the language before logging in (or entering local mode) had no way to do so.

## Solution

A `SegmentedControl` language picker is now shown at the bottom of the login screen, identical in behaviour to the one in Settings. It uses the same `usePreferences` hook and persists the selection via `AsyncStorage` — so the chosen language is remembered across sessions.

## Note

I have not been able to test this on a real device yet — that will happen over the next few days. The implementation was generated with [Claude Code](https://claude.ai/code).